### PR TITLE
fix borked link in LINUX.md

### DIFF
--- a/docs/misc/LINUX.md
+++ b/docs/misc/LINUX.md
@@ -68,4 +68,4 @@ If the above doesn't fix the issue, ask in the previously linked Discord server.
 
 If the above *does* fix the issue, try connecting a USB device to the controller you forwarded. If that works, congratulations, you can proceed to the next step!
 
-You have to start with the [dependencies](docs/install/DEPENDENCIES.md).
+You have to start with the [dependencies](/docs/install/DEPENDENCIES.md).


### PR DESCRIPTION
without "/": [sunst0rm-guide/docs/misc/docs/install/DEPENDENCIES.md](https://github.com/Arna13/sunst0rm-guide/blob/main/docs/misc/docs/install/DEPENDENCIES.md)

with "/": [sunst0rm-guide/docs/install/DEPENDENCIES.md](https://github.com/Arna13/sunst0rm-guide/blob/main/docs/install/DEPENDENCIES.md)